### PR TITLE
Use standalone prop-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "lint-staged": "^3.0.3",
     "npmpub": "^3.1.0",
     "pre-commit": "^1.1.3",
+    "prop-types": "^15.5.10",
     "react": "^15.3.2",
     "react-dom": "^15.3.2",
     "react-styleguidist": "^5.0.0-beta8",
@@ -70,6 +71,8 @@
   },
   "peerDependencies": {
     "react": "15.x",
-    "react-dom": "15.x"
-  }
+    "react-dom": "15.x",
+    "prop-types": "^15.x"
+  },
+  "dependencies": {}
 }

--- a/src/ScrollSync.js
+++ b/src/ScrollSync.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 
 /**
  * ScrollSync provider component

--- a/src/ScrollSyncPane.js
+++ b/src/ScrollSyncPane.js
@@ -1,7 +1,8 @@
 /* eslint react/no-find-dom-node: 0 */
 
-import { Component, PropTypes } from 'react'
+import { Component } from 'react'
 import ReactDOM from 'react-dom'
+import PropTypes from 'prop-types'
 
 /**
  * ScrollSyncPane Component


### PR DESCRIPTION
> React.PropTypes is deprecated as of React v15.5. Please use the prop-types library instead.

[source](https://facebook.github.io/react/docs/typechecking-with-proptypes.html)

<hr>

Nevertheless, Thanks for this awesome component.