### PR TITLE
[FIX] Ensure valid changes on multi-scroll panes

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,8 +70,8 @@
     "webpack": "^1.13.2"
   },
   "peerDependencies": {
-    "react": "15.x",
-    "react-dom": "15.x",
+    "react": "0.14.x || 15.x",
+    "react-dom": "0.14.x || 15.x",
     "prop-types": "^15.x"
   },
   "dependencies": {}

--- a/src/ScrollSync.js
+++ b/src/ScrollSync.js
@@ -68,8 +68,17 @@ export default class ScrollSync extends Component {
   }
 
   syncScrollPositions = (scrolledPane) => {
-    const { scrollTop, scrollHeight, clientHeight,
-      scrollLeft, scrollWidth, clientWidth } = scrolledPane
+    const {
+      scrollTop,
+      scrollHeight,
+      clientHeight,
+      scrollLeft,
+      scrollWidth,
+      clientWidth
+    } = scrolledPane
+
+    const scrollTopOffset = scrollHeight - clientHeight
+    const scrollLeftOffset = scrollWidth - clientWidth
 
     const { proportional, vertical, horizontal } = this.props
 
@@ -82,11 +91,11 @@ export default class ScrollSync extends Component {
         const paneHeight = pane.scrollHeight - clientHeight
         const paneWidth = pane.scrollWidth - clientWidth
         /* Adjust the scrollTop position of it accordingly */
-        if (vertical) {
-          pane.scrollTop = proportional ? (paneHeight * scrollTop) / (scrollHeight - clientHeight) : scrollTop // eslint-disable-line
+        if (vertical && scrollTopOffset > 0) {
+          pane.scrollTop = proportional ? (paneHeight * scrollTop) / scrollTopOffset : scrollTop // eslint-disable-line
         }
-        if (horizontal) {
-          pane.scrollLeft = proportional ? (paneWidth * scrollLeft) / (scrollWidth - clientWidth) : scrollLeft // eslint-disable-line
+        if (horizontal && scrollLeftOffset > 0) {
+          pane.scrollLeft = proportional ? (paneWidth * scrollLeft) / scrollLeftOffset : scrollLeft // eslint-disable-line
         }
         /* Re-attach event listeners after we're done scrolling */
         window.requestAnimationFrame(() => {


### PR DESCRIPTION
# WHAT

In the current implementation its possible that a division by `0` occurs if a sync container has multiple panes with different directions (at least one vertical and one horizontal). In this case some elements have no `overflow-x` or `overflow-y` value but a fixed value. To avoid collision a check is added to ensure only valid results will be set.

Furthermore for backwards compatibility the previous `react` version was added to the peer dependencies.