### PR TITLE
feat: add disable/enable hook

### DIFF
--- a/src/ScrollSync.js
+++ b/src/ScrollSync.js
@@ -12,13 +12,15 @@ export default class ScrollSync extends Component {
     children: PropTypes.element.isRequired,
     proportional: PropTypes.bool,
     vertical: PropTypes.bool,
-    horizontal: PropTypes.bool
+    horizontal: PropTypes.bool,
+    enabled: PropTypes.bool
   };
 
   static defaultProps = {
     proportional: true,
     vertical: true,
-    horizontal: true
+    horizontal: true,
+    enabled: true
   };
 
   static childContextTypes = {
@@ -72,6 +74,10 @@ export default class ScrollSync extends Component {
   }
 
   handlePaneScroll = (node, group) => {
+    if (!this.props.enabled) {
+      return;
+    }
+
     window.requestAnimationFrame(() => {
       this.syncScrollPositions(node, group)
     })

--- a/src/ScrollSync.js
+++ b/src/ScrollSync.js
@@ -75,7 +75,7 @@ export default class ScrollSync extends Component {
 
   handlePaneScroll = (node, group) => {
     if (!this.props.enabled) {
-      return;
+      return
     }
 
     window.requestAnimationFrame(() => {

--- a/src/example.md
+++ b/src/example.md
@@ -1,5 +1,7 @@
 To use ScrollSync you have to wrap your scrollable content (ensure that you have `overflow: auto`
  in CSS) in `ScrollSyncPane` and then wrap everything in `ScrollSync`.
+
+If you want to provide a toggle for users to turn the scroll syncing on and off, you can use the `enabled={false}` setting on the main `ScrollSync` element. Note that this disables the scroll syncing for all groups.
  
 ```
 <ScrollSync>
@@ -102,3 +104,4 @@ Provide an arbitrary group name in the `group` prop to ScrollSyncPane components
   </div>
 </ScrollSync>
 ```
+


### PR DESCRIPTION
Provide an `enabled` toggle for users to turn the scroll syncing on and off on the main `ScrollSync` element. Note that this disables the scroll syncing for all groups.