### PR TITLE
fix(IE11): Replace find method to avoid exceptions in IE11

### DIFF
--- a/src/ScrollSync.js
+++ b/src/ScrollSync.js
@@ -83,7 +83,7 @@ export default class ScrollSync extends Component {
       return false
     }
 
-    return this.panes[group].find(pane => pane === node)
+    return this.panes[group].filter(pane => pane === node)[0]
   }
 
   handlePaneScroll = (node, groups) => {


### PR DESCRIPTION
IE11 does not support find method (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find). This breaks IE11 pages which use react-scroll-sync.
Replaced it with filter to avoid IE11 exceptions.