### PR TITLE
Removing legacy contextTypes

### DIFF
--- a/src/ScrollSyncPane.js
+++ b/src/ScrollSyncPane.js
@@ -29,11 +29,6 @@ export default class ScrollSyncPane extends Component {
     enabled: true
   }
 
-  static contextTypes = {
-    registerPane: PropTypes.func,
-    unregisterPane: PropTypes.func
-  }
-
   componentDidMount() {
     if (this.props.enabled) {
       this.node = this.props.attachTo || ReactDOM.findDOMNode(this)


### PR DESCRIPTION
This removes console warning in StrictMode