### PR TITLE
Removing warnings on Strict Mode and more

### DIFF
--- a/src/ScrollSyncPane.js
+++ b/src/ScrollSyncPane.js
@@ -1,7 +1,6 @@
 /* eslint react/no-find-dom-node: 0 */
 
-import { Component } from 'react'
-import ReactDOM from 'react-dom'
+import { Component, Children, createRef, cloneElement } from 'react'
 import PropTypes from 'prop-types'
 import ScrollSyncContext from './support/ScrollSyncContext'
 
@@ -18,7 +17,7 @@ export default class ScrollSyncPane extends Component {
   static contextType = ScrollSyncContext;
 
   static propTypes = {
-    children: PropTypes.node.isRequired,
+    children: PropTypes.element.isRequired,
     attachTo: PropTypes.object,
     group: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
     enabled: PropTypes.bool
@@ -29,22 +28,29 @@ export default class ScrollSyncPane extends Component {
     enabled: true
   }
 
+  constructor(props) {
+    super(props)
+    this.childRef = createRef()
+  }
+
   componentDidMount() {
     if (this.props.enabled) {
-      this.node = this.props.attachTo || ReactDOM.findDOMNode(this)
-      this.context.registerPane(this.node, this.toArray(this.props.group))
+      this.node = this.props.attachTo || this.childRef.current
+      if (this.node) {
+        this.context.registerPane(this.node, this.toArray(this.props.group))
+      }
     }
   }
 
   componentDidUpdate(prevProps) {
-    if (this.props.enabled && this.props.group !== prevProps.group) {
+    if (this.node && this.props.enabled && this.props.group !== prevProps.group) {
       this.context.unregisterPane(this.node, this.toArray(prevProps.group))
       this.context.registerPane(this.node, this.toArray(this.props.group))
     }
   }
 
   componentWillUnmount() {
-    if (this.props.enabled) {
+    if (this.node && this.props.enabled) {
       this.context.unregisterPane(this.node, this.toArray(this.props.group))
     }
   }
@@ -52,6 +58,10 @@ export default class ScrollSyncPane extends Component {
   toArray = groups => [].concat(groups)
 
   render() {
-    return this.props.children
+    if (this.props.attachTo) {
+      return this.props.children
+    }
+    return cloneElement(Children.only(this.props.children), { ref: this.childRef })
+
   }
 }

--- a/src/ScrollSyncPane.js
+++ b/src/ScrollSyncPane.js
@@ -29,11 +29,6 @@ export default class ScrollSyncPane extends Component {
     enabled: true
   }
 
-  static contextTypes = {
-    registerPane: PropTypes.func,
-    unregisterPane: PropTypes.func
-  }
-
   componentDidMount() {
     if (this.props.enabled) {
       this.node = this.props.attachTo || ReactDOM.findDOMNode(this)


### PR DESCRIPTION
- Deleted leftovers from old context api (removes warning)
- Removed use of findDOMNode (removes warning)
- ScrollSyncPane "attachTo" now uses a reference (React.createRef or useRef)
- ScrollSyncPane "attachTo" can be changed dynamically
- ScrollSyncPane "enabled" can be changed dynamically
- ScrollSyncPane "attachTo" have priority over child component. If no "attachTo" is provided, a single child component with ref support is expected (for example a div or input, not a React.Fragment or more that one child)