### PR TITLE
fix: less strict prop type so that it works inside SSR

### DIFF
--- a/src/ScrollSyncPane.js
+++ b/src/ScrollSyncPane.js
@@ -28,8 +28,7 @@ export default class ScrollSyncPane extends Component {
     enabled: PropTypes.bool,
     innerRef: PropTypes.oneOfType([// Either a function
       PropTypes.func,
-    // Or the instance of a DOM native element (see the note about SSR)
-      PropTypes.shape({ current: PropTypes.instanceOf(Element) })])
+      PropTypes.shape({ current: PropTypes.any })])
   };
 
   static defaultProps = {


### PR DESCRIPTION
Solves https://github.com/okonet/react-scroll-sync/issues/91

Another solution would be to add a shim for `Element`, but a more loose PropType is probably fine here.

More info: https://stackoverflow.com/a/51127130