### PR TITLE
fix: pane groups incompletely reset after scroll

### DIFF
--- a/src/ScrollSync.jsx
+++ b/src/ScrollSync.jsx
@@ -129,7 +129,10 @@ export default class ScrollSync extends Component {
           this.syncScrollPosition(scrolledPane, pane)
           /* Re-attach event listeners after we're done scrolling */
           window.requestAnimationFrame(() => {
-            this.addEvents(pane, groups)
+            const paneGroups = Object.keys(this.panes).filter((group) =>
+              this.panes[group].includes(pane)
+            )
+            this.addEvents(pane, paneGroups)
           })
         }
       })


### PR DESCRIPTION
This fixes https://github.com/okonet/react-scroll-sync/issues/95.