### PR TITLE
fix: updating exports property so that it works properly

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,30 @@
+# TypeScript Types Migration
+
+## Important: Remove Community `@types` Package
+
+Starting from version 1.0.0, `react-scroll-sync` provides its own TypeScript type definitions built-in.  
+**You must uninstall the community `@types/react-scroll-sync` package to avoid type conflicts and ensure you are using the latest, official types.**
+
+### Migration Steps
+
+1. **Uninstall the community types:**
+
+   ```sh
+   npm uninstall @types/react-scroll-sync
+   # or, if you use yarn:
+   yarn remove @types/react-scroll-sync
+   ```
+
+2. **Update your imports (if needed):**
+
+   You can now use `react-scroll-sync` directly in your TypeScript code without any additional type packages.
+
+   ```ts
+   import { ScrollSync, ScrollSyncPane } from "react-scroll-sync";
+   ```
+
+3. **Check your code:**
+
+   The official types are included automatically. If you encounter any type errors, ensure the old `@types/react-scroll-sync` package is fully removed from your `node_modules` and `package.json`.
+
+---

--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ https://react-sync-scroll.netlify.app/
 
 https://react-sync-scroll.netlify.app/
 
+## Migration from v0 to v1
+
+If you are upgrading from `react-scroll-sync` v0 to v1, please review the [Migration Guide](./MIGRATION.md).  
+Version 1.0.0 and above provide built-in TypeScript type definitions, so you **must uninstall the community `@types/react-scroll-sync` package** to avoid type conflicts. The guide includes all required steps to ensure a smooth upgrade.
+
 ## License
 
 MIT

--- a/package.json
+++ b/package.json
@@ -8,10 +8,14 @@
   "module": "./dist/index.mjs",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "module": "./dist/index.mjs",
-      "main": "./dist/index.cjs",
-      "umd": "./dist/index.js"
+     "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     }
   },
   "files": [

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,9 +1,9 @@
-import { defineConfig } from "tsup";
+import { defineConfig } from 'tsup';
 
 export default defineConfig({
   clean: true,
   dts: true,
-  entry: ["src/index.ts"],
-  format: ["cjs", "esm", "iife"],
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
   sourcemap: true,
 });


### PR DESCRIPTION
Updating exports property so that it works correctly. I tried to get it to work with the umd output but it didn't seem to work. So I'm just going to dual output this library into esm and cjs for now. I also added a migrate guide to migration from v0.x.x to 1.x.x. @okonet Can we get this into main asap? I would like to fix this issue so this library is broken for anyone who tries to pull in the new version.