### PR TITLE
fix: fixing path to esm output bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,12 +5,12 @@
   "type": "module",
   "types": "./dist/index.d.ts",
   "main": "./dist/index.cjs",
-  "module": "./dist/index.mjs",
+  "module": "./dist/index.js",
   "exports": {
     ".": {
      "import": {
         "types": "./dist/index.d.ts",
-        "default": "./dist/index.mjs"
+        "default": "./dist/index.js"
       },
       "require": {
         "types": "./dist/index.d.cts",


### PR DESCRIPTION
The output extension to the esm js bundle changed when I removed the umd output. @okonet I'm hoping this is the last one. I'm pretty confident that this should fix it.